### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ Should get better battery life and performance out of this compared to the Intel
 
 Created with the following command:
 
-```$ nativefier --enable-es3-apis --icon discord.icns --browserwindow-options '{ "fullscreenable": "true", "simpleFullscreen": "false" }' --darwin-dark-mode-support --background-color #36393f https://discord.com/app```
+```$ nativefier --enable-es3-apis --icon discord.icns --browserwindow-options '{ "fullscreenable": "true", "simpleFullscreen": "false" }' --darwin-dark-mode-support --background-color "#36393f" https://discord.com/app```
 
 Credit to Discord user Jesca for providing the command: https://support.discord.com/hc/en-us/community/posts/360052558393-Discord-on-Apple-M1-Devices?page=4#community_comment_360014125174


### PR DESCRIPTION
The --background-color option needs its argument in quotes to recognize it as a string, otherwise the command does not run properly.