### PR TITLE
Add context menus for messages, links, and media

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const { app, BrowserWindow } = require('electron');
+const fs = require('fs');
 
 // Check for updates
 const { autoUpdater } = require("electron-updater");
@@ -45,6 +46,13 @@ function createWindow() {
     win.setAutoHideMenuBar(true);
     
     win.loadURL("https://discord.com/app");
+
+    // Inject custom JavaScript
+    let injectFilePath = path.join(process.resourcesPath, 'inject.js');
+    if (!fs.existsSync(injectFilePath)) injectFilePath = './inject.js';
+    fs.readFile(injectFilePath, 'utf-8', (_, data) => {
+        win.webContents.executeJavaScript(data);
+    });
 
     // shows when ready
     win.once('ready-to-show', () => {

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow } = require('electron');
+const { app, BrowserWindow, shell } = require('electron');
 const fs = require('fs');
 
 // Check for updates
@@ -52,6 +52,11 @@ function createWindow() {
     if (!fs.existsSync(injectFilePath)) injectFilePath = './inject.js';
     fs.readFile(injectFilePath, 'utf-8', (_, data) => {
         win.webContents.executeJavaScript(data);
+    });
+
+    win.webContents.on('new-window', (e, url) => {
+        e.preventDefault();
+        shell.openExternal(url);
     });
 
     // shows when ready

--- a/inject.js
+++ b/inject.js
@@ -1,10 +1,11 @@
 document.body.addEventListener("contextmenu", e => {
     // If the message text is right clicked, the grandparent element will be the message element,
     // and if the message background is clicked, the parent element will be the message element.
-    let message = e.target;
     let isMessage = false;
-    for (let i = 0; i < 4; i++) {
+    let message = e.target;
+    for (let i = 0; i < 6; i++) {
         message = message.parentElement;
+
         if (elementHasClassPrefix(message, "message")) {
             isMessage = true;
             break;
@@ -17,53 +18,183 @@ document.body.addEventListener("contextmenu", e => {
         || elementHasClassPrefix(e.target, "username")
         || elementHasClassPrefix(e.target, "repliedTextPreview")
         || elementHasClassPrefix(e.target, "avatar")) {
-            return;
-        }
+        return;
+    }
 
-    // Temporarily position the "..." button at the mouse cursor,
-    // so that the context menu pops up there. Then move it back again.
     const moreButton = message.querySelector("[aria-label='More']");
-    moreButton.style.position = "fixed";
-    moreButton.style.top = e.clientY + "px";
-    moreButton.style.left = e.clientX + "px";
-    moreButton.click();
-    moreButton.style.position = "";
-    moreButton.style.top = "";
-    moreButton.style.left = "";
-
-
-    // Add "add reaction" item to context menu
+    showMenuUsingButton(e, moreButton);
     const menu = document.getElementById("message-actions").firstChild;
-    const referenceItem = menu.firstChild;
-    const reactionItem = referenceItem.cloneNode(true);
-    const reactButton = message.querySelector("[aria-label='Add Reaction']");
-    reactionItem.id = "message-actions-react";
-    reactionItem.children[0].innerHTML = "Add Reaction";
-    reactionItem.children[1].innerHTML = reactButton.innerHTML;
-    menu.insertBefore(reactionItem, referenceItem);
+    const focusedClassName = getFocusClassNameUsingMenuItem(menu.firstChild);
 
-    // Focus the reference item so that it gets the "focused-???" class,
-    // then find this class (we only know it starts with focused-),
-    // and get the full name. Then use it with the self-made events.
-    referenceItem.focus();
-    const focusedClassName = Array.from(referenceItem.classList).find(x => x.startsWith("focused-"));
-    referenceItem.classList.remove(focusedClassName);
-    referenceItem.blur();
     // Discord's own event is unreliable after making changes here,
     // therefore this one is needed to make it more stable.
-    referenceItem.addEventListener("mouseenter", () => referenceItem.classList.add(focusedClassName));
+    menu.firstChild.addEventListener("mouseover", e => e.target.classList.add(focusedClassName));
+    menu.lastChild.addEventListener("mouseover", e => e.target.classList.add(focusedClassName));
+
+    if (e.target.tagName == "A" || e.target.tagName == "IMG") {
+        const items = [];
+        if (e.target.tagName == "IMG") {
+            menu.appendChild(createSeparator());
+
+            // Copy Image
+            const copyImageItem = createMenuItem(menu, "Copy Image")
+            items.push(copyImageItem);
+            menu.appendChild(copyImageItem);
+            copyImageItem.addEventListener("click", () => {
+                copyImage(e.target.parentElement.href)
+                menu.remove();
+            });
+
+            // For some reason it keeps being highlighted otherwise.
+            copyImageItem.addEventListener("mouseover", () => {
+                copyImageItem.previousSibling.previousSibling.previousSibling.classList.remove(focusedClassName);
+            });
+
+            // Save Image (this just opens it in a browser for now,
+            // but is here for consistency with regards to the official client)
+            const saveImageItem = createMenuItem(menu, "Save Image");
+            items.push(saveImageItem);
+            menu.appendChild(saveImageItem);
+            saveImageItem.addEventListener("click", async () => {
+                window.open(e.target.parentElement.href, "_blank");
+                menu.remove();
+            });
+
+            menu.appendChild(createSeparator());
+
+            // Copy Image Link
+            const copyLinkItem = createMenuItem(menu, "Copy Link");
+            items.push(copyLinkItem);
+            menu.appendChild(copyLinkItem);
+            copyLinkItem.addEventListener("click", async () => {
+                await navigator.clipboard.writeText(e.target.parentElement.href);
+                menu.remove();
+            });
+
+            // Open Image Link
+            const openLinkItem = createMenuItem(menu, "Open Link");
+            items.push(openLinkItem);
+            menu.appendChild(openLinkItem);
+            openLinkItem.addEventListener("click", async () => {
+                window.open(e.target.parentElement.href, "_blank");
+                menu.remove();
+            });
+        } else {
+            menu.appendChild(createSeparator());
+
+            // Copy Link
+            const copyLinkItem = createMenuItem(menu, "Copy Link");
+            items.push(copyLinkItem);
+            menu.appendChild(copyLinkItem);
+            copyLinkItem.addEventListener("click", async () => {
+                await navigator.clipboard.writeText(e.target.href);
+                menu.remove();
+            });
+
+            // For some reason it keeps being highlighted otherwise.
+            copyLinkItem.addEventListener("mouseover", () => {
+                copyLinkItem.previousSibling.previousSibling.previousSibling.classList.remove(focusedClassName);
+            });
+
+            // Open Link
+            const openLinkItem = createMenuItem(menu, "Open Link");
+            items.push(openLinkItem);
+            menu.appendChild(openLinkItem);
+            openLinkItem.addEventListener("click", async () => {
+                e.target.click();
+                menu.remove();
+            });
+        }
+
+        for (const item of items) {
+            item.addEventListener("mouseover", () => item.classList.add(focusedClassName));
+            item.addEventListener("mouseleave", () => item.classList.remove(focusedClassName));
+            item.addEventListener("focus", () => item.classList.add(focusedClassName));
+            item.addEventListener("blur", () => item.classList.remove(focusedClassName));
+        }
+    }
+
+    // Add "add reaction" item to context menu
+    const reactButton = message.querySelector("[aria-label='Add Reaction']");
+    const reactionItem = createMenuItem(menu, "Add Reaction", reactButton.innerHTML);
+    menu.insertBefore(reactionItem, menu.firstChild);
 
     reactionItem.addEventListener("click", () => reactButton.click());
-    reactionItem.addEventListener("mouseenter", () => {
+    reactionItem.addEventListener("mouseover", () => {
         reactionItem.classList.add(focusedClassName);
         // For some reason it keeps being highlighted otherwise.
-        referenceItem.classList.remove(focusedClassName);
+        reactionItem.nextSibling.classList.remove(focusedClassName);
     });
-    reactionItem.addEventListener("focus", () => reactionItem.classList.add(focusedClassName));
     reactionItem.addEventListener("mouseleave", () => reactionItem.classList.remove(focusedClassName));
+    reactionItem.addEventListener("focus", () => reactionItem.classList.add(focusedClassName));
     reactionItem.addEventListener("blur", () => reactionItem.classList.remove(focusedClassName));
 });
 
+function copyImage(url) {
+    // Dump the image in a canvas, // and then convert the canvas to a blob.
+    // This way any non-png image will be turned into a png.
+    // This is necessary since the Clipboard API only supports png.
+    const canvas = document.createElement("canvas");
+    const context = canvas.getContext("2d");
+    const image = new Image();
+    image.setAttribute("crossorigin", "anonymous");
+    image.src = url;
+    image.addEventListener("load", () => {
+        canvas.width = image.naturalWidth;
+        canvas.height = image.naturalHeight;
+        context.drawImage(image, 0, 0, image.naturalWidth, image.naturalHeight);
+        canvas.toBlob(async blob => {
+            await navigator.clipboard.write([new ClipboardItem({
+                "image/png": blob
+            })]);
+        });
+    });
+}
+
+function createMenuItem(referenceMenu, title, icon) {
+    const item = referenceMenu.firstChild.cloneNode(true);
+    item.id = "";
+    item.children[0].innerHTML = title;
+    if (icon) item.children[1].innerHTML = icon;
+    else item.children[1].remove();
+
+    return item;
+}
+
+function createSeparator() {
+    const separator = document.createElement("div");
+    separator.setAttribute("role", "separator");
+    separator.style.boxSizing = "border-box";
+    separator.style.margin = "4px";
+    separator.style.borderBottom = "1px solid var(--background-modifier-accent)";
+
+    return separator;
+}
+
 function elementHasClassPrefix(element, classPrefix) {
-    return Array.from(element.classList).some(x => x.startsWith(classPrefix));
+    return Array.from(element.classList).some(x => x.startsWith(classPrefix + "-"));
+}
+
+function getFocusClassNameUsingMenuItem(menuItem) {
+    // Focus the reference item so that it gets the "focused-???" class,
+    // then find this class (we only know it starts with focused-),
+    // and get the full name. Then use it with the self-made events.
+    menuItem.focus();
+    const focusedClassName = Array.from(menuItem.classList).find(x => x.startsWith("focused-"));
+    menuItem.classList.remove(focusedClassName);
+    menuItem.blur();
+
+    return focusedClassName;
+}
+
+function showMenuUsingButton(e, button) {
+    // Temporarily position the "..." button at the mouse cursor,
+    // so that the context menu pops up there. Then move it back again.
+    button.style.position = "fixed";
+    button.style.top = e.clientY + "px";
+    button.style.left = e.clientX + "px";
+    button.click();
+    button.style.position = "";
+    button.style.top = "";
+    button.style.left = "";
 }

--- a/inject.js
+++ b/inject.js
@@ -129,7 +129,10 @@ document.body.addEventListener("contextmenu", e => {
     const reactionItem = createMenuItem(menu, "Add Reaction", reactButton.innerHTML);
     menu.insertBefore(reactionItem, menu.firstChild);
 
-    reactionItem.addEventListener("click", () => reactButton.click());
+    reactionItem.addEventListener("click", () => {
+        reactButton.click()
+        menu.remove();
+    });
     reactionItem.addEventListener("mouseover", () => {
         reactionItem.classList.add(focusedClassName);
         // For some reason it keeps being highlighted otherwise.

--- a/inject.js
+++ b/inject.js
@@ -1,0 +1,69 @@
+document.body.addEventListener("contextmenu", e => {
+    // If the message text is right clicked, the grandparent element will be the message element,
+    // and if the message background is clicked, the parent element will be the message element.
+    let message = e.target;
+    let isMessage = false;
+    for (let i = 0; i < 4; i++) {
+        message = message.parentElement;
+        if (elementHasClassPrefix(message, "message")) {
+            isMessage = true;
+            break;
+        }
+    }
+
+    // Only show the context menu if the message was clicked,
+    // and the clicked thing doesn't have its own context menu.
+    if (!isMessage
+        || elementHasClassPrefix(e.target, "username")
+        || elementHasClassPrefix(e.target, "repliedTextPreview")
+        || elementHasClassPrefix(e.target, "avatar")) {
+            return;
+        }
+
+    // Temporarily position the "..." button at the mouse cursor,
+    // so that the context menu pops up there. Then move it back again.
+    const moreButton = message.querySelector("[aria-label='More']");
+    moreButton.style.position = "fixed";
+    moreButton.style.top = e.clientY + "px";
+    moreButton.style.left = e.clientX + "px";
+    moreButton.click();
+    moreButton.style.position = "";
+    moreButton.style.top = "";
+    moreButton.style.left = "";
+
+
+    // Add "add reaction" item to context menu
+    const menu = document.getElementById("message-actions").firstChild;
+    const referenceItem = menu.firstChild;
+    const reactionItem = referenceItem.cloneNode(true);
+    const reactButton = message.querySelector("[aria-label='Add Reaction']");
+    reactionItem.id = "message-actions-react";
+    reactionItem.children[0].innerHTML = "Add Reaction";
+    reactionItem.children[1].innerHTML = reactButton.innerHTML;
+    menu.insertBefore(reactionItem, referenceItem);
+
+    // Focus the reference item so that it gets the "focused-???" class,
+    // then find this class (we only know it starts with focused-),
+    // and get the full name. Then use it with the self-made events.
+    referenceItem.focus();
+    const focusedClassName = Array.from(referenceItem.classList).find(x => x.startsWith("focused-"));
+    referenceItem.classList.remove(focusedClassName);
+    referenceItem.blur();
+    // Discord's own event is unreliable after making changes here,
+    // therefore this one is needed to make it more stable.
+    referenceItem.addEventListener("mouseenter", () => referenceItem.classList.add(focusedClassName));
+
+    reactionItem.addEventListener("click", () => reactButton.click());
+    reactionItem.addEventListener("mouseenter", () => {
+        reactionItem.classList.add(focusedClassName);
+        // For some reason it keeps being highlighted otherwise.
+        referenceItem.classList.remove(focusedClassName);
+    });
+    reactionItem.addEventListener("focus", () => reactionItem.classList.add(focusedClassName));
+    reactionItem.addEventListener("mouseleave", () => reactionItem.classList.remove(focusedClassName));
+    reactionItem.addEventListener("blur", () => reactionItem.classList.remove(focusedClassName));
+});
+
+function elementHasClassPrefix(element, classPrefix) {
+    return Array.from(element.classList).some(x => x.startsWith(classPrefix));
+}

--- a/inject.js
+++ b/inject.js
@@ -31,24 +31,26 @@ document.body.addEventListener("contextmenu", e => {
     menu.firstChild.addEventListener("mouseover", e => e.target.classList.add(focusedClassName));
     menu.lastChild.addEventListener("mouseover", e => e.target.classList.add(focusedClassName));
 
-    if (e.target.tagName == "A" || e.target.tagName == "IMG") {
+    if (e.target.tagName == "A" || e.target.tagName == "IMG" || "VIDEO") {
         const items = [];
         if (e.target.tagName == "IMG") {
             menu.appendChild(createSeparator());
 
             // Copy Image
-            const copyImageItem = createMenuItem(menu, "Copy Image")
-            items.push(copyImageItem);
-            menu.appendChild(copyImageItem);
-            copyImageItem.addEventListener("click", () => {
-                copyImage(e.target.parentElement.href)
-                menu.remove();
-            });
+            if (!e.target.parentElement.href.endsWith(".gif")) {
+                const copyImageItem = createMenuItem(menu, "Copy Image")
+                items.push(copyImageItem);
+                menu.appendChild(copyImageItem);
+                copyImageItem.addEventListener("click", () => {
+                    copyImage(e.target.parentElement.href)
+                    menu.remove();
+                });
 
-            // For some reason it keeps being highlighted otherwise.
-            copyImageItem.addEventListener("mouseover", () => {
-                copyImageItem.previousSibling.previousSibling.previousSibling.classList.remove(focusedClassName);
-            });
+                // For some reason it keeps being highlighted otherwise.
+                copyImageItem.addEventListener("mouseover", () => {
+                    copyImageItem.previousSibling.previousSibling.previousSibling.classList.remove(focusedClassName);
+                });
+            }
 
             // Save Image (this just opens it in a browser for now,
             // but is here for consistency with regards to the official client)
@@ -58,6 +60,11 @@ document.body.addEventListener("contextmenu", e => {
             saveImageItem.addEventListener("click", async () => {
                 window.open(e.target.parentElement.href, "_blank");
                 menu.remove();
+            });
+
+            // For some reason it keeps being highlighted otherwise.
+            saveImageItem.addEventListener("mouseover", () => {
+                saveImageItem.previousSibling.previousSibling.previousSibling.classList.remove(focusedClassName);
             });
 
             menu.appendChild(createSeparator());
@@ -81,13 +88,16 @@ document.body.addEventListener("contextmenu", e => {
             });
         } else {
             menu.appendChild(createSeparator());
+            const link = e.target.tagName == "A"
+                ? e.target.href
+                : e.target.src;
 
             // Copy Link
             const copyLinkItem = createMenuItem(menu, "Copy Link");
             items.push(copyLinkItem);
             menu.appendChild(copyLinkItem);
             copyLinkItem.addEventListener("click", async () => {
-                await navigator.clipboard.writeText(e.target.href);
+                await navigator.clipboard.writeText(link);
                 menu.remove();
             });
 
@@ -101,7 +111,7 @@ document.body.addEventListener("contextmenu", e => {
             items.push(openLinkItem);
             menu.appendChild(openLinkItem);
             openLinkItem.addEventListener("click", async () => {
-                e.target.click();
+                window.open(link, "_blank");
                 menu.remove();
             });
         }

--- a/package.json
+++ b/package.json
@@ -35,11 +35,12 @@
     "electron": "13.0.1",
     "electron-builder": "22.11.5",
     "electron-webpack": "2.8.2",
-    "webpack": "5.37.1"
+    "webpack": "4.42.1"
   },
   "build": {
     "appId": "Discord-m1",
     "extends": null,
+    "extraResources": ["inject.js"],
     "mac": {
       "category" : "public.app-category.social-networking",
       "target": [


### PR DESCRIPTION
This pull request adds context menus that normally only work in the desktop version. This is done by triggering a button click to open a menu, and then adding some missing buttons.

Links will also open in the browser, rather than in an Electron window. 